### PR TITLE
Command to install Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ pfSense
 pkg install py27-speedtest-cli
 ```
 
+## Python 3.7
+```console
+pkg add http://pkg.freebsd.org/freebsd:11:x86:64/latest/All/python37-3.7.2.txz
+```
+
 ## Repository
 https://docs.netgate.com/pfsense/en/latest/packages/installing-freebsd-packages.html
 


### PR DESCRIPTION
Add Command reference to install Python 3.7